### PR TITLE
Optionally specify the name of the migrations table

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,7 +8,11 @@
 
 [[projects]]
   name = "github.com/gin-gonic/gin"
-  packages = [".","binding","render"]
+  packages = [
+    ".",
+    "binding",
+    "render"
+  ]
   revision = "e2212d40c62a98b388a5eb48ecbdcf88534688ba"
   version = "v1.1.4"
 
@@ -30,9 +34,19 @@
   revision = "2402d76f3d41f928c7902a765dfc872356dd3aad"
 
 [[projects]]
+  name = "github.com/google/jsonapi"
+  packages = ["."]
+  revision = "46d3ced0434461be12e555852e2f1a9ed382e139"
+  version = "1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/jinzhu/gorm"
-  packages = [".","dialects/mysql","dialects/postgres"]
+  packages = [
+    ".",
+    "dialects/mysql",
+    "dialects/postgres"
+  ]
   revision = "3a9e91ab372120a0e35b518430255308e3d8d5ea"
 
 [[projects]]
@@ -42,7 +56,11 @@
 
 [[projects]]
   name = "github.com/lib/pq"
-  packages = [".","hstore","oid"]
+  packages = [
+    ".",
+    "hstore",
+    "oid"
+  ]
   revision = "3cd0097429be7d611bb644ef85b42bfb102ceea4"
 
 [[projects]]
@@ -69,11 +87,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/shwoodard/jsonapi"
-  packages = ["."]
-  revision = "a337a3bc9f0a02cb5d289564e5c97c65e46efc42"
-
-[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "4b6ea7319e214d98c938f12692336f7ca9348d6b"
@@ -86,7 +99,10 @@
 
 [[projects]]
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish"]
+  packages = [
+    "bcrypt",
+    "blowfish"
+  ]
   revision = "3fbbcd23f1cb824e69491a5930cfeff09b12f4d2"
 
 [[projects]]
@@ -115,7 +131,10 @@
 [[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
-  packages = ["bson","internal/json"]
+  packages = [
+    "bson",
+    "internal/json"
+  ]
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
@@ -127,6 +146,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8ba948469169884a23a428953de148598e5e001e7deb7f188bd5e6c52847f766"
+  inputs-digest = "3b41d591e8de7998037ac0efe14c94a47a6c96aeb111f54fcf2fd1d40d64de44"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,7 +11,7 @@
   name = "github.com/pborman/uuid"
 
 [[constraint]]
-  name = "github.com/shwoodard/jsonapi"
+  name = "github.com/google/jsonapi"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/olio/api/base.go
+++ b/olio/api/base.go
@@ -17,8 +17,18 @@ func (api *OlioBaseCoreAPI) Init() {
 	log.Info("Initializing core api.")
 }
 
-func (api *OlioBaseCoreAPI) RunMigrations(migrations []db.Migration) {
-	migrationManager := db.NewMigrationManager(api.ConnectionManager, migrations)
+func (api *OlioBaseCoreAPI) RunMigrations(migrations []db.Migration, tableName ...string) {
+	if len(tableName) > 1 {
+		log.Fatalf("Wrong number of args (%d), function takes 1 or 2 args", 1+len(tableName))
+	}
+
+	var migrationManager *db.MigrationManager
+	if len(tableName) == 1 {
+		migrationManager = db.NewMigrationManager(api.ConnectionManager, migrations, tableName[0])
+	} else {
+		migrationManager = db.NewMigrationManager(api.ConnectionManager, migrations)
+	}
+
 	if err := migrationManager.Migrate(); err != nil {
 		log.Fatal("Failed to run migrations: ", err)
 		os.Exit(1)

--- a/olio/db/migration_manager.go
+++ b/olio/db/migration_manager.go
@@ -3,16 +3,18 @@ package db
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/olioapps/service-skeleton-go/olio/dao"
 	"github.com/olioapps/service-skeleton-go/olio/util"
+	log "github.com/sirupsen/logrus"
 )
 
 type MigrationManager struct {
 	connectionManager *dao.ConnectionManager
 	migrations        []Migration
+	tableName         string
 }
 
 type Migration func() error
@@ -24,28 +26,25 @@ func (self *MigrationManager) getRequiredSchemaVersion() int {
 func (self *MigrationManager) getCurrentVersion() (int, error) {
 	db := self.connectionManager.GetDb()
 	var version int
-	row := db.Table("migrations").Select("version").Row()
+	row := db.Table(self.tableName).Select("version").Row()
 	row.Scan(&version)
 	return version, db.Error
 }
 
 func (self *MigrationManager) perequisites() error {
 	db := self.connectionManager.GetDb()
-	if db.Exec(`
-		CREATE TABLE IF NOT EXISTS
-		migrations (
-			version int
-		)
-	`).Error != nil {
+	sqlStr := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version int)", self.tableName)
+	if db.Exec(sqlStr).Error != nil {
 		return db.Error
 	}
 
-	rows, error := db.Table("migrations").Select("version").Rows()
+	rows, error := db.Table(self.tableName).Select("version").Rows()
 	if error != nil {
 		return error
 	}
 	if rows == nil || rows.Err() == sql.ErrNoRows || !rows.Next() {
-		return db.Exec("INSERT INTO migrations values (?)", 0).Error
+		sqlStr = fmt.Sprintf("INSERT INTO %s values (?)", self.tableName)
+		return db.Exec(sqlStr, 0).Error
 	}
 	rows.Close()
 	return nil
@@ -53,7 +52,8 @@ func (self *MigrationManager) perequisites() error {
 
 func (self *MigrationManager) incrementVersion(targetVersion int) error {
 	db := self.connectionManager.GetDb()
-	return db.Exec("UPDATE migrations SET version = ?", targetVersion).Error
+	sqlStr := fmt.Sprintf("UPDATE %s SET version = ?", self.tableName)
+	return db.Exec(sqlStr, targetVersion).Error
 }
 
 func (self *MigrationManager) Migrate() error {
@@ -99,10 +99,18 @@ func (self *MigrationManager) Migrate() error {
 	return self.Migrate()
 }
 
-func NewMigrationManager(connectionManager *dao.ConnectionManager, migrations []Migration) *MigrationManager {
+func NewMigrationManager(connectionManager *dao.ConnectionManager, migrations []Migration, tableName ...string) *MigrationManager {
+	if len(tableName) > 1 {
+		log.Fatalf("Wrong number of args (%d), function takes 2 or 3 args", 2+len(tableName))
+	}
+
 	migrationManager := MigrationManager{}
 	migrationManager.connectionManager = connectionManager
 	migrationManager.migrations = migrations
+
+	if len(tableName) == 1 {
+		migrationManager.tableName = tableName[0]
+	}
 
 	return &migrationManager
 }

--- a/olio/service/resources/base_resource.go
+++ b/olio/service/resources/base_resource.go
@@ -1,18 +1,19 @@
 package resources
 
 import (
-	"errors"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/olioapps/service-skeleton-go/olio/api"
-	"github.com/olioapps/service-skeleton-go/olio/util"
 	"net/url"
-	"github.com/shwoodard/jsonapi"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/jsonapi"
+	"github.com/j0ni/service-skeleton-go/olio/api"
+	"github.com/j0ni/service-skeleton-go/olio/util"
 )
 
 type BaseResource struct {
@@ -37,7 +38,7 @@ func (self *BaseResource) ReturnJSONAPI(c *gin.Context, status int, record inter
 	w.Header().Set("Content-Type", "application/json")
 
 	if record != nil {
-		if err := jsonapi.MarshalOnePayload(w, record); err != nil {
+		if err := jsonapi.MarshalPayload(w, record); err != nil {
 			self.ReturnJSONException(c, api.NewRuntimeException(err.Error()))
 		}
 	}
@@ -54,7 +55,7 @@ func (self *BaseResource) ReturnJSONAPIArray(c *gin.Context, status int, records
 			Data: []*jsonapi.Node{},
 		})
 	} else {
-		if err := jsonapi.MarshalManyPayload(w, records); err != nil {
+		if err := jsonapi.MarshalPayload(w, records); err != nil {
 			self.ReturnJSONException(c, api.NewRuntimeException(err.Error()))
 		}
 	}


### PR DESCRIPTION
I hope you're OK with pull requests for this - no worries if not, we can maintain a fork (though I'd prefer not to!). Also, if you would prefer a different approach, let me know and I will rework this.

The rationale is that we need to avoid collisions with a number of other systems making use of the same database but using different schemata. Since the app also creates the schema by migration, we can't keep the migrations table inside the new schema, so we need to have multiple migrations tables in the public schema. In that context, `migrations` is too ambiguous.

I had to update a dependency too, because the old one didn't work. See [this PR](https://github.com/google/jsonapi/pull/90) for rationale.